### PR TITLE
Fix time-based suggestions to send UTC hours to match backend SQL

### DIFF
--- a/src/NewDiaryEntryForm.test.tsx
+++ b/src/NewDiaryEntryForm.test.tsx
@@ -203,6 +203,56 @@ describe("NewDiaryEntryForm", () => {
     expect(timeBasedHeader).toBeNull();
   });
 
+  it("should send UTC hours to the time-based suggestions API", async () => {
+    let capturedVariables: Record<string, unknown> | undefined;
+
+    server.use(
+      http.post("*/api/v1/graphql", async ({ request }): Promise<Response> => {
+        const body: unknown = await request.json();
+        if (!isGraphQLRequest(body)) {
+          return HttpResponse.json({
+            errors: [{ message: "Invalid request" }],
+          });
+        }
+        const query: string = body.query || "";
+
+        if (query.includes("TopEntriesAroundHour")) {
+          capturedVariables = body.variables;
+          return HttpResponse.json({
+            data: { food_diary_top_entries_around_hour: [] },
+          });
+        }
+
+        if (query.includes("GetRecentEntryItems")) {
+          return HttpResponse.json({
+            data: { food_diary_diary_entry_recent: [] },
+          });
+        }
+
+        if (query.includes("GetTopLoggedItems")) {
+          return HttpResponse.json({
+            data: { food_diary_diary_entry: [] },
+          });
+        }
+
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+
+    render(() => <NewDiaryEntryForm onSubmit={() => ({})} />);
+
+    await waitFor(
+      () => {
+        expect(capturedVariables).toBeDefined();
+      },
+      { timeout: 5000 },
+    );
+
+    const expectedHour = new Date().getUTCHours();
+    expect(capturedVariables?.startHour).toBe(Math.max(0, expectedHour - 1));
+    expect(capturedVariables?.endHour).toBe(Math.min(23, expectedHour + 1));
+  });
+
   it("should display Search tab and allow searching for items", async () => {
     const user = await import("@testing-library/user-event").then((m) =>
       m.default.setup(),

--- a/src/NewDiaryEntryForm.tsx
+++ b/src/NewDiaryEntryForm.tsx
@@ -61,7 +61,7 @@ const NewDiaryEntryForm: Component<Props> = ({ onSubmit }: Props) => {
     (getRecentItemsQuery() as GetRecentEntriesResponse | undefined)?.data
       ?.food_diary_diary_entry_recent ?? [];
 
-  const currentHour: number = new Date().getHours();
+  const currentHour: number = new Date().getUTCHours();
   const startHour: number = Math.max(0, currentHour - 1);
   const endHour: number = Math.min(23, currentHour + 1);
 

--- a/src/test-setup-browser.ts
+++ b/src/test-setup-browser.ts
@@ -139,11 +139,11 @@ const graphqlHandler: HttpResponseResolver = async ({ request }) => {
     });
   }
 
-  // Handle GetEntriesAroundTime query
-  if (query.includes("GetEntriesAroundTime")) {
+  // Handle TopEntriesAroundHour query
+  if (query.includes("TopEntriesAroundHour")) {
     return HttpResponse.json({
       data: {
-        food_diary_diary_entry: [],
+        food_diary_top_entries_around_hour: [],
       },
     });
   }


### PR DESCRIPTION
The backend top_entries_around_hour function extracts hours in UTC
(consumed_at AT TIME ZONE 'UTC'), but the frontend was sending local
browser hours via getHours(), causing the query window to be off by the
UTC offset (e.g. 7 hours behind for PDT users).

Also fixes the acceptance test MSW handler which was matching the old
GetEntriesAroundTime query name instead of TopEntriesAroundHour.

https://claude.ai/code/session_017EsjFVcjE4xjVaQDtWKgTE